### PR TITLE
[W-10592639] fix github action condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WITH_V: true
     - name: Prerelease
-      if: ${{ github.event_name != 'master' }}
+      if: github.ref != 'refs/heads/master'
       uses: ncipollo/release-action@v1
       with:
         prerelease: true
@@ -28,7 +28,7 @@ jobs:
         artifacts: Mulesoft.zip
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Release
-      if: ${{ github.event_name == 'master' }}
+      if: github.ref == 'refs/heads/master'
       uses: ncipollo/release-action@v1
       with:
         tag: ${{ steps.tag_version.outputs.new_tag }}


### PR DESCRIPTION
ref: W-10592639

I messed up on the condition between pre-release and release. Here's the fix, the expectation is that it will create actual releases when PRs are merged (thus pushing to the master branch), and create pre-releases otherwise.