### PR TITLE
[W-11127438] add alt text rules

### DIFF
--- a/Mulesoft/AltText.yml
+++ b/Mulesoft/AltText.yml
@@ -1,0 +1,13 @@
+# Copyright (c) 2022, salesforce.com, inc.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+# For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+scope: raw
+extends: existence
+message: |
+  "'%s' either does not have an alt text, or alt text is distorted due to the presence of commas 
+  (if this is the case, please use image::name.jpg[alt="your alt text here"] to fix)."
+ignorecase: true
+level: error
+raw:
+  - 'image::[\w-_\.]+\[(?:[\s]*|(?!(alt=)).*,.*)\]'

--- a/Mulesoft/AltText.yml
+++ b/Mulesoft/AltText.yml
@@ -5,9 +5,9 @@
 scope: raw
 extends: existence
 message: |
-  "'%s' either does not have an alt text, or alt text is distorted due to the presence of commas 
-  (if this is the case, please use image::name.jpg[alt="your alt text here"] to fix)."
+  "'%s' either does not have an alt text, or alt text is broken due to the presence of commas 
+  (if this is the case, please add "" around your alt text to fix to fix)."
 ignorecase: true
 level: error
 raw:
-  - 'image::[\w-_\.]+\[(?:[\s]*|(?!(alt=)).*,.*)\]'
+  - 'image::[\w-_\.]+\[(?:[\s]*|[^"]*,[^"]*)\]'

--- a/Mulesoft/AltText.yml
+++ b/Mulesoft/AltText.yml
@@ -6,7 +6,7 @@ scope: raw
 extends: existence
 message: |
   "'%s' either does not have an alt text, or alt text is broken due to the presence of commas 
-  (if this is the case, please add "" around your alt text to fix to fix)."
+  (if this is the case, please add "" around your alt text to fix)."
 ignorecase: true
 level: error
 raw:


### PR DESCRIPTION
ref: [W-11127438](https://gus.lightning.force.com/a07EE00000woRgSYAU)

add a vale rule to check that image alt texts:
- are present
- if alt text contains commas, have double parentheses around it (since it breaks the HTML)

https://www.loom.com/share/a7a75b5f760f4f468417e0724bd1a271