### PR TITLE
[W-11127438] separate alt text rules

### DIFF
--- a/Mulesoft/AltTextMalformed.yml
+++ b/Mulesoft/AltTextMalformed.yml
@@ -1,0 +1,13 @@
+# Copyright (c) 2022, salesforce.com, inc.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+# For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+scope: raw
+extends: existence
+message: |
+  '%s' has a malformed alt text due to the presence of commas. Please add "" around your alt texts.
+  Example: image::pic.png["By adding the double quotation marks around this alt text, it preserves the format."]
+ignorecase: true
+level: error
+raw:
+  - 'image::[\w-_\.]+(\[[^"]).*,[\s]*.+([^"]\])'

--- a/Mulesoft/AltTextMalformed.yml
+++ b/Mulesoft/AltTextMalformed.yml
@@ -10,4 +10,4 @@ message: |
 ignorecase: true
 level: error
 raw:
-  - 'image::[\w-_\.]+(\[[^"]).*,[\s]*.+([^"]\])'
+  - 'image::[\w-_\.]+(jpg|jpeg|png|svg)(\[[^"]).*,[\s]*.+([^"]\])'

--- a/Mulesoft/AltTextMissing.yml
+++ b/Mulesoft/AltTextMissing.yml
@@ -8,4 +8,4 @@ message: "'%s' does not have an alt text, making it inaccessible for screen read
 ignorecase: true
 level: error
 raw:
-  - 'image::[\w-_\.]+\[\s*\]'
+  - 'image::[\w-_\.]+(jpg|jpeg|png|svg)(\[\s*\]|\["\s*"\]|\s)'

--- a/Mulesoft/AltTextMissing.yml
+++ b/Mulesoft/AltTextMissing.yml
@@ -4,10 +4,8 @@
 # For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 scope: raw
 extends: existence
-message: |
-  "'%s' either does not have an alt text, or alt text is broken due to the presence of commas 
-  (if this is the case, please add "" around your alt text to fix)."
+message: "'%s' does not have an alt text, making it inaccessible for screen reader users. Please add an alt text."
 ignorecase: true
 level: error
 raw:
-  - 'image::[\w-_\.]+\[(?:[\s]*|[^"]*,[^"]*)\]'
+  - 'image::[\w-_\.]+\[\s*\]'


### PR DESCRIPTION
ref: W-11127438

Separate the alt text rules defined in #8  so they can have different error messages. Previously, the 2 rules share the same message which can get confusing.

Sample output:

```
vale --config ~/.vale/.vale.ini '/Users/gcheung/git/docs-hosting/modules/ROOT/pages/ch2-deploy-shared-space.adoc'

 /Users/gcheung/git/docs-hosting/modules/ROOT/pages/ch2-deploy-shared-space.adoc
 27:1  error  'image::rtm-get-from-exchange.png[Get,  Mulesoft.AltTextMalformed 
              from Exchange page]' has a malformed                              
              alt text due to the presence of                                   
              commas. Please add "" around your alt                             
              texts. Example: image::pic.png["By                                
              adding the double quotation marks                                 
              around this alt text, it preserves the                            
              format."]                                                         
 57:1  error  'image::test.jpn[]' does not            Mulesoft.AltTextMissing   
              have an alt text, making it                                       
              inaccessible for screen reader                                    
              users. Please add an alt text.                                    
 58:1  error  'image::test.jpn[ ]' does not           Mulesoft.AltTextMissing   
              have an alt text, making it                                       
              inaccessible for screen reader                                    
              users. Please add an alt text.                                    
 59:1  error  'image::test-wo-alt-text.png[j,sdf]'    Mulesoft.AltTextMalformed 
              has a malformed alt text due to                                   
              the presence of commas. Please add                                
              "" around your alt texts. Example:                                
              image::pic.png["By adding the double                              
              quotation marks around this alt                                   
              text, it preserves the format."]   
```
